### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ In addition to this, it is also possible to use curl on any of the above platfor
 * [boost](https://www.boost.org/)
 
 ## Installation :inbox_tray:
-`NFHTTP` is a [Cmake](https://cmake.org/) project, while you are free to download the prebuilt static libraries it is recommended to use Cmake to install this project into your wider project. In order to add this into a wider Cmake project (who needs monorepos anyway?), simply add the following line to your `CMakeLists.txt` file:
+`NFHTTP` is a [Cmake](https://cmake.org/) project, while you are free to download the prebuilt static libraries it is recommended to use Cmake to install this project into your wider project. In order to add this into a wider Cmake project (who needs monorepos anyway?), simply add the following lines to your `CMakeLists.txt` file:
 ```
 add_subdirectory(NFHTTP)
+
+# Link NFHTTP to your executables or target libs
+target_link_libraries(your_target_lib_or_executable NFHTTP)
 ```
 
 ### For iOS/OSX


### PR DESCRIPTION
Added `target_link_libraries` to installation instructions. Undefined reference error got me for couple of days only to realize I was missing the linking of the library. This will make the instructions clear and avoid such trouble for other devs specially for beginners like me.