### PR TITLE
Make the lib work on Android

### DIFF
--- a/source/ClientCurl.cpp
+++ b/source/ClientCurl.cpp
@@ -288,7 +288,7 @@ void ClientCurl::HandleInfo::configureCurlHandle() {
 
   curl_easy_setopt(handle, CURLOPT_TIMEOUT, 30);
 
-#if __APPLE__
+#if __APPLE__ | ANDROID
   curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, false);
   curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, false);
 #endif


### PR DESCRIPTION
The lib doesn't work on android unless I disable the ssl cert verification. I'm not really good at this, but if this solution looks stupid, can you suggest any workaround to make this work on android without disabling security features?