### PR TITLE
Update generate-version.py to work with Python 2 and 3

### DIFF
--- a/tools/generate-version.py
+++ b/tools/generate-version.py
@@ -31,14 +31,14 @@ def main():
         output_dir = sys.argv[1]
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    print 'Generating nfhttp_generated_header.h in ' + output_dir
+    print ('Generating nfhttp_generated_header.h in ' + output_dir)
     generated_header_filename = os.path.join(output_dir, 'nfhttp_generated_header.h')
     generated_header = open(generated_header_filename, 'w')
     generated_header.write('// This is a generated header from generate-version.py\n')
     cwd = os.getcwd()
-    print 'PYTHON CWD: ' + cwd
-    git_count = subprocess.check_output(['git', 'rev-list', '--count', 'HEAD'], cwd = cwd)
-    git_describe = subprocess.check_output(['git', 'describe', '--always'], cwd = cwd)
+    print ('PYTHON CWD: ' + cwd)
+    git_count = subprocess.check_output(['git', 'rev-list', '--count', 'HEAD'], cwd = cwd, universal_newlines = True)
+    git_describe = subprocess.check_output(['git', 'describe', '--always'], cwd = cwd, universal_newlines = True)
     generated_header.write('#define NFHTTP_VERSION "' + git_count.strip() + '-' + git_describe.strip() + '"\n')
 
 


### PR DESCRIPTION
I modified generate-version.py to work with Python 3 while still working with Python 2. Tested with Python 3.8 on Windows and Python 2.7 on Linux.