### PR TITLE
Remove cmakelint since its build is broken and it is not being maintained :(

### DIFF
--- a/ci/ios.py
+++ b/ci/ios.py
@@ -8,7 +8,6 @@ from build_options import BuildOptions
 
 def main():
     buildOptions = BuildOptions()
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCpp", "Lint CPP Files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
@@ -22,12 +21,10 @@ def main():
     buildOptions.setDefaultWorkflow("Empty workflow", [])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("build", "Production Build", [
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -40,9 +37,6 @@ def main():
 
     library_target = 'NFHTTP'
     nfbuild = NFBuildOSX()
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/linux.py
+++ b/ci/linux.py
@@ -31,7 +31,6 @@ def main():
     buildOptions = BuildOptions()
     buildOptions.addOption("debug", "Enable Debug Mode")
     buildOptions.addOption("installDependencies", "Install dependencies")
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
     buildOptions.addOption("makeBuildDirectory",
@@ -46,13 +45,11 @@ def main():
     buildOptions.setDefaultWorkflow("Empty workflow", [])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("clang_build", "Production Clang Build", [
         'llvmToolchain',
-        'lintCmake',
         'makeBuildDirectory',
         'generateProject',
         'buildTargetLibrary',
@@ -62,7 +59,6 @@ def main():
 
     buildOptions.addWorkflow("gcc_build", "Production build with gcc", [
         'gnuToolchain',
-        'lintCmake',
         'makeBuildDirectory',
         'generateProject',
         'buildTargetLibrary',
@@ -78,9 +74,6 @@ def main():
 
     if buildOptions.checkOption(options, 'debug'):
         nfbuild.build_type = 'Debug'
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/linux.sh
+++ b/ci/linux.sh
@@ -38,7 +38,6 @@ sudo apt-get install -y -q --no-install-recommends apt-utils \
     git \
     unzip \
     software-properties-common \
-    python-software-properties \
     make
 
 # Extra repo for gcc-4.9 so we don't have to use 4.8

--- a/ci/nfbuild.py
+++ b/ci/nfbuild.py
@@ -102,27 +102,6 @@ class NFBuild(object):
         if not lint_result:
             sys.exit(1)
 
-    def lintCmakeFile(self, filepath):
-        self.build_print("Linting: " + filepath)
-        return subprocess.call(['cmakelint', filepath]) == 0
-
-    def lintCmakeDirectory(self, directory):
-        passed = True
-        for root, dirnames, filenames in os.walk(directory):
-            for filename in filenames:
-                if not filename.endswith('CMakeLists.txt'):
-                    continue
-                full_filepath = os.path.join(root, filename)
-                if not self.lintCmakeFile(full_filepath):
-                    passed = False
-        return passed
-
-    def lintCmake(self):
-        lint_result = self.lintCmakeFile('CMakeLists.txt')
-        lint_result &= self.lintCmakeDirectory('source')
-        if not lint_result:
-            sys.exit(1)
-
     def runIntegrationTests(self):
         # Build the CLI target
         cli_target_name = 'NFHTTPCLI'

--- a/ci/osx.py
+++ b/ci/osx.py
@@ -31,7 +31,6 @@ def main():
     buildOptions = BuildOptions()
     buildOptions.addOption("debug", "Enable Debug Mode")
     buildOptions.addOption("installDependencies", "Install dependencies")
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCpp", "Lint CPP Files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
@@ -60,18 +59,15 @@ def main():
 
     buildOptions.addWorkflow("local_it", "Run local integration tests", [
         'debug',
-        'lintCmake',
         'integrationTests'
     ])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("address_sanitizer", "Run address sanitizer", [
         'debug',
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -82,7 +78,6 @@ def main():
 
     buildOptions.addWorkflow("code_coverage", "Collect code coverage", [
         'debug',
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -92,7 +87,6 @@ def main():
     ])
 
     buildOptions.addWorkflow("build", "Production Build", [
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -111,9 +105,6 @@ def main():
 
     if buildOptions.checkOption(options, 'debug'):
         nfbuild.build_type = 'Debug'
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,3 @@
 pyyaml
 flake8
-cmakelint
 requests

--- a/ci/windows.ps1
+++ b/ci/windows.ps1
@@ -24,7 +24,6 @@ try
 	& nfdriver_env/Scripts/pip.exe install urllib3
 	& nfdriver_env/Scripts/pip.exe install pyyaml
 	& nfdriver_env/Scripts/pip.exe install flake8
-	& nfdriver_env/Scripts/pip.exe install cmakelint
 
 	if($build -eq "android"){
 		& nfdriver_env/Scripts/python.exe ci/androidwindows.py


### PR DESCRIPTION
I also removed the `python-software-properties` package since I think it is deprecated in favor of just using `software-properties-common`, but I'm testing locally on Ubuntu 18.04, which I think is newer than the images used in CI. If it messes up the CI builds I will revert that change. 