### PR TITLE
Fix builds by removing broken dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - run:
           name: Build OSX
           command: USE_CURL=1 sh ci/osx.sh build
+          no_output_timeout: 45m
       - store_artifacts:
           path: build/output/libNFHTTP.zip
           destination: libNFHTTP.zip
@@ -59,6 +60,7 @@ jobs:
       - run:
           name: Build iOS
           command: BUILD_IOS=1 USE_CURL=1 sh ci/osx.sh build
+          no_output_timeout: 45m
       - store_artifacts:
           path: build/output/libNFHTTP.zip
           destination: libNFHTTP.zip
@@ -72,6 +74,7 @@ jobs:
       - run:
           name: Build Android
           command: BUILD_ANDROID=1 USE_CURL=1 sh ci/osx.sh build
+          no_output_timeout: 45m
       - store_artifacts:
           path: libNFHTTP-androidx86.zip
           destination: libNFHTTP-androidx86.zip

--- a/ci/Brewfile
+++ b/ci/Brewfile
@@ -1,4 +1,0 @@
-brew "clang-format"
-brew "cmake"
-brew "ninja"
-brew "wget"

--- a/ci/ios.py
+++ b/ci/ios.py
@@ -8,7 +8,6 @@ from build_options import BuildOptions
 
 def main():
     buildOptions = BuildOptions()
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCpp", "Lint CPP Files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
@@ -22,12 +21,10 @@ def main():
     buildOptions.setDefaultWorkflow("Empty workflow", [])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("build", "Production Build", [
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -40,9 +37,6 @@ def main():
 
     library_target = 'NFHTTP'
     nfbuild = NFBuildOSX()
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/linux.py
+++ b/ci/linux.py
@@ -31,7 +31,6 @@ def main():
     buildOptions = BuildOptions()
     buildOptions.addOption("debug", "Enable Debug Mode")
     buildOptions.addOption("installDependencies", "Install dependencies")
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
     buildOptions.addOption("makeBuildDirectory",
@@ -46,13 +45,11 @@ def main():
     buildOptions.setDefaultWorkflow("Empty workflow", [])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("clang_build", "Production Clang Build", [
         'llvmToolchain',
-        'lintCmake',
         'makeBuildDirectory',
         'generateProject',
         'buildTargetLibrary',
@@ -62,7 +59,6 @@ def main():
 
     buildOptions.addWorkflow("gcc_build", "Production build with gcc", [
         'gnuToolchain',
-        'lintCmake',
         'makeBuildDirectory',
         'generateProject',
         'buildTargetLibrary',
@@ -78,9 +74,6 @@ def main():
 
     if buildOptions.checkOption(options, 'debug'):
         nfbuild.build_type = 'Debug'
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/linux.sh
+++ b/ci/linux.sh
@@ -38,7 +38,6 @@ sudo apt-get install -y -q --no-install-recommends apt-utils \
     git \
     unzip \
     software-properties-common \
-    python-software-properties \
     make
 
 # Extra repo for gcc-4.9 so we don't have to use 4.8

--- a/ci/nfbuild.py
+++ b/ci/nfbuild.py
@@ -102,27 +102,6 @@ class NFBuild(object):
         if not lint_result:
             sys.exit(1)
 
-    def lintCmakeFile(self, filepath):
-        self.build_print("Linting: " + filepath)
-        return subprocess.call(['cmakelint', filepath]) == 0
-
-    def lintCmakeDirectory(self, directory):
-        passed = True
-        for root, dirnames, filenames in os.walk(directory):
-            for filename in filenames:
-                if not filename.endswith('CMakeLists.txt'):
-                    continue
-                full_filepath = os.path.join(root, filename)
-                if not self.lintCmakeFile(full_filepath):
-                    passed = False
-        return passed
-
-    def lintCmake(self):
-        lint_result = self.lintCmakeFile('CMakeLists.txt')
-        lint_result &= self.lintCmakeDirectory('source')
-        if not lint_result:
-            sys.exit(1)
-
     def runIntegrationTests(self):
         # Build the CLI target
         cli_target_name = 'NFHTTPCLI'

--- a/ci/osx.py
+++ b/ci/osx.py
@@ -31,7 +31,6 @@ def main():
     buildOptions = BuildOptions()
     buildOptions.addOption("debug", "Enable Debug Mode")
     buildOptions.addOption("installDependencies", "Install dependencies")
-    buildOptions.addOption("lintCmake", "Lint cmake files")
     buildOptions.addOption("lintCpp", "Lint CPP Files")
     buildOptions.addOption("lintCppWithInlineChange",
                            "Lint CPP Files and fix them")
@@ -60,18 +59,15 @@ def main():
 
     buildOptions.addWorkflow("local_it", "Run local integration tests", [
         'debug',
-        'lintCmake',
         'integrationTests'
     ])
 
     buildOptions.addWorkflow("lint", "Run lint workflow", [
-        'lintCmake',
         'lintCppWithInlineChange'
     ])
 
     buildOptions.addWorkflow("address_sanitizer", "Run address sanitizer", [
         'debug',
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -82,7 +78,6 @@ def main():
 
     buildOptions.addWorkflow("code_coverage", "Collect code coverage", [
         'debug',
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -92,7 +87,6 @@ def main():
     ])
 
     buildOptions.addWorkflow("build", "Production Build", [
-        'lintCmake',
         'lintCpp',
         'makeBuildDirectory',
         'generateProject',
@@ -111,9 +105,6 @@ def main():
 
     if buildOptions.checkOption(options, 'debug'):
         nfbuild.build_type = 'Debug'
-
-    if buildOptions.checkOption(options, 'lintCmake'):
-        nfbuild.lintCmake()
 
     if buildOptions.checkOption(options, 'lintCppWithInlineChange'):
         nfbuild.lintCPP(make_inline_changes=True)

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -23,6 +23,19 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Fail mac build quickly for debugging
+python2 -c "print('Hello')"
+which python
+which python2
+which "python2.7"
+virtualenv --python=$(which python2) nfhttp_env
+source nfhttp_env/bin/activate
+python -c "print('Hello from venv')"
+which python
+which python2
+which "python2.7"
+exit 1
+
 # Install system dependencies
 # Don't use Brewfile because tapping bundle takes so long that the build times out
 # https://ideas.circleci.com/ideas/CCI-I-1197
@@ -48,7 +61,6 @@ if [ -n "$BUILD_IOS" ]; then
 else
     if [ -n "$BUILD_ANDROID" ]; then
     	brew cask install android-ndk
-
         python ci/android.py "$@"
     else
         python ci/osx.py "$@"

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -23,19 +23,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# Fail mac build quickly for debugging
-python2 -c "print('Hello')"
-which python
-which python2
-which "python2.7"
-virtualenv --python=$(which python2) nfhttp_env
-source nfhttp_env/bin/activate
-python -c "print('Hello from venv')"
-which python
-which python2
-which "python2.7"
-exit 1
-
 # Install system dependencies
 # Don't use Brewfile because tapping bundle takes so long that the build times out
 # https://ideas.circleci.com/ideas/CCI-I-1197
@@ -46,7 +33,7 @@ brew install wget
 
 # Should fix the error: /usr/local/opt/python/bin/python2.7: bad interpreter: No such file or directory
 # We really should move to python3
-brew link --overwrite python
+ln -s "/usr/local/bin/python" "/usr/local/opt/python/bin/python2.7"
 
 # Install virtualenv
 virtualenv --python=$(which python2) nfhttp_env

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -31,6 +31,10 @@ brew install cmake
 brew install ninja
 brew install wget
 
+# Should fix the error: /usr/local/opt/python/bin/python2.7: bad interpreter: No such file or directory
+# We really should move to python3
+brew link --overwrite python
+
 # Install virtualenv
 virtualenv --python=$(which python2) nfhttp_env
 source nfhttp_env/bin/activate

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -23,6 +23,8 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+exit 1
+
 # Install system dependencies
 # Don't use Brewfile because tapping bundle takes so long that the build times out
 # https://ideas.circleci.com/ideas/CCI-I-1197

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -23,8 +23,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-exit 1
-
 # Install system dependencies
 # Don't use Brewfile because tapping bundle takes so long that the build times out
 # https://ideas.circleci.com/ideas/CCI-I-1197
@@ -35,7 +33,7 @@ brew install wget
 
 # Should fix the error: /usr/local/opt/python/bin/python2.7: bad interpreter: No such file or directory
 # We really should move to python3
-ln -s "/usr/local/bin/python" "/usr/local/opt/python/bin/python2.7"
+brew unlink python && brew link python
 
 # Install virtualenv
 virtualenv --python=$(which python2) nfhttp_env

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -24,9 +24,12 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Install system dependencies
-# Don't use brew bundle because tapping bundle takes so long that the build times out
-HOMEBREW_BREWFILE=${DIR}/Brewfile
-brew install $(cat ${HOMEBREW_BREWFILE} | grep -v "#")
+# Don't use Brewfile because tapping bundle takes so long that the build times out
+# https://ideas.circleci.com/ideas/CCI-I-1197
+brew install clang-format
+brew install cmake
+brew install ninja
+brew install wget
 
 # Install virtualenv
 virtualenv --python=$(which python2) nfhttp_env

--- a/ci/osx.sh
+++ b/ci/osx.sh
@@ -24,8 +24,9 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Install system dependencies
+# Don't use brew bundle because tapping bundle takes so long that the build times out
 HOMEBREW_BREWFILE=${DIR}/Brewfile
-brew bundle --file=${HOMEBREW_BREWFILE}
+brew install $(cat ${HOMEBREW_BREWFILE} | grep -v "#")
 
 # Install virtualenv
 virtualenv --python=$(which python2) nfhttp_env

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,4 +1,3 @@
 pyyaml
 flake8
-cmakelint
 requests

--- a/ci/windows.ps1
+++ b/ci/windows.ps1
@@ -24,7 +24,6 @@ try
 	& nfdriver_env/Scripts/pip.exe install urllib3
 	& nfdriver_env/Scripts/pip.exe install pyyaml
 	& nfdriver_env/Scripts/pip.exe install flake8
-	& nfdriver_env/Scripts/pip.exe install cmakelint
 
 	if($build -eq "android"){
 		& nfdriver_env/Scripts/python.exe ci/androidwindows.py


### PR DESCRIPTION
Removes:
- cmakelint, since its own python build seems broken and it is no longer being maintained :( 
- brew bundle, since it seems to no longer be included on the CI macos image, and installing it takes so long that the build times out
- The python-software-properties package, since it is deprecated in favor of just using software-properties-common