### PR TITLE
docs: fix simple typo, statment -> statement

### DIFF
--- a/libraries/sqlite/shell.c
+++ b/libraries/sqlite/shell.c
@@ -2726,7 +2726,7 @@ static int shell_exec(
       if( zStmtSql==0 ) zStmtSql = "";
       while( IsSpace(zStmtSql[0]) ) zStmtSql++;
 
-      /* save off the prepared statment handle and reset row count */
+      /* save off the prepared statement handle and reset row count */
       if( pArg ){
         pArg->pStmt = pStmt;
         pArg->cnt = 0;


### PR DESCRIPTION
There is a small typo in libraries/sqlite/shell.c, libraries/sqlite/sqlite3.c.

Should read `statement` rather than `statment`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md